### PR TITLE
Changed the SOURCE define from BSD to DEFAULT to get it to work under Ubuntu 18.04

### DIFF
--- a/vban.c
+++ b/vban.c
@@ -20,7 +20,7 @@
  *  USA.
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <endian.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Replaced the '#define _BSD_SOURCE' with '#define _DEFAULT_SOURCE' in order to get it to compile under Ubuntu 18.04